### PR TITLE
Diablo3 fix squash

### DIFF
--- a/src/audio_core/sink/cubeb_sink.h
+++ b/src/audio_core/sink/cubeb_sink.h
@@ -96,12 +96,20 @@ private:
  */
 std::vector<std::string> ListCubebSinkDevices(bool capture);
 
+// REVERSION - function GetCubebLatency() reintroduced from EA-3833 - DIABLO 3 FIX
+/**
+ * Get the reported latency for this sink.
+ *
+ * @return Minimum latency for this sink.
+ */
+u32 GetCubebLatency();
+
 /**
  * Check if this backend is suitable for use.
  * Checks if enabled, its latency, whether it opens successfully, etc.
  *
  * @return True is this backend is suitable, false otherwise.
  */
-bool IsCubebSuitable();
+// bool IsCubebSuitable(); // REVERTED BACK TO GetCubebLatency() FROM 3833
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sdl2_sink.cpp
+++ b/src/audio_core/sink/sdl2_sink.cpp
@@ -230,6 +230,13 @@ std::vector<std::string> ListSDLSinkDevices(bool capture) {
     return device_list;
 }
 
+/* REVERSION to 3833 - function GetSDLLatency() REINTRODUCED FROM 3833 - DIABLO 3 FIX */
+u32 GetSDLLatency() {
+    return TargetSampleCount * 2;
+}
+
+// REVERTED back to 3833 - Below function IsSDLSuitable() removed, reverting to GetSDLLatency() above. - DIABLO 3 FIX
+/*
 bool IsSDLSuitable() {
 #if !defined(HAVE_SDL2)
     return false;
@@ -267,5 +274,6 @@ bool IsSDLSuitable() {
     return true;
 #endif
 }
+*/
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sdl2_sink.h
+++ b/src/audio_core/sink/sdl2_sink.h
@@ -87,12 +87,20 @@ private:
  */
 std::vector<std::string> ListSDLSinkDevices(bool capture);
 
+// REVERSION - function GetSDLLatency() reintroduced from EA-3833 - DIABLO 3 FIX
 /**
+ * Get the reported latency for this sink.
+ *
+ * @return Minimum latency for this sink.
+ */
+u32 GetSDLLatency();
+
+/** REVERTED back to 3833 - Below function IsSDLSuitable() removed, reverting to GetSDLLatency() above. - DIABLO 3 FIX
  * Check if this backend is suitable for use.
  * Checks if enabled, its latency, whether it opens successfully, etc.
  *
  * @return True is this backend is suitable, false otherwise.
  */
-bool IsSDLSuitable();
+//bool IsSDLSuitable(); // REVERTED for GetSDLLatency() from EA-3833
 
 } // namespace AudioCore::Sink

--- a/src/audio_core/sink/sink_details.cpp
+++ b/src/audio_core/sink/sink_details.cpp
@@ -25,7 +25,8 @@ namespace {
 struct SinkDetails {
     using FactoryFn = std::unique_ptr<Sink> (*)(std::string_view);
     using ListDevicesFn = std::vector<std::string> (*)(bool);
-    using SuitableFn = bool (*)();
+    using LatencyFn = u32 (*)(); // REINTRODUCED FROM 3833 - DIABLO 3 FIX
+    // using SuitableFn = bool (*)(); // REVERTED FOR ABOVE - DIABLO 3 FIX
 
     /// Name for this sink.
     Settings::AudioEngine id;
@@ -33,9 +34,17 @@ struct SinkDetails {
     FactoryFn factory;
     /// A method to call to list available devices.
     ListDevicesFn list_devices;
+    /// Method to get the latency of this backend - REINTRODUCED FROM 3833 - DIABLO 3 FIX
+    LatencyFn latency;
     /// Check whether this backend is suitable to be used.
-    SuitableFn is_suitable;
+    /// SuitableFn is_suitable; // REVERTED FOR LatencyFn latency ABOVE - DIABLO 3 FIX
 };
+
+// NOTE TO PROBABLY FIX LATER FOR ANDROID - the return value "0u" for the first HAVE_OBOE 
+// section below was just copied from the null section so there's a somewhat valid value
+// being returned, since the previous "true" value probably isn't compatible with the 
+// previous EA-3833 code. (HAVE_OBOE was introduced in a later release.) Eventually need 
+// to change "0u" for something else directly from the oboe_sink.cpp functions.
 
 // sink_details is ordered in terms of desirability, with the best choice at the top.
 constexpr SinkDetails sink_details[] = {
@@ -46,7 +55,7 @@ constexpr SinkDetails sink_details[] = {
             return std::make_unique<OboeSink>();
         },
         [](bool capture) { return std::vector<std::string>{"Default"}; },
-        []() { return true; },
+        []() { return 0u; },
     },
 #endif
 #ifdef HAVE_CUBEB
@@ -56,7 +65,7 @@ constexpr SinkDetails sink_details[] = {
             return std::make_unique<CubebSink>(device_id);
         },
         &ListCubebSinkDevices,
-        &IsCubebSuitable,
+        &GetCubebLatency,
     },
 #endif
 #ifdef HAVE_SDL2
@@ -66,7 +75,7 @@ constexpr SinkDetails sink_details[] = {
             return std::make_unique<SDLSink>(device_id);
         },
         &ListSDLSinkDevices,
-        &IsSDLSuitable,
+        &GetSDLLatency,
     },
 #endif
     SinkDetails{
@@ -75,7 +84,7 @@ constexpr SinkDetails sink_details[] = {
             return std::make_unique<NullSink>(device_id);
         },
         [](bool capture) { return std::vector<std::string>{"null"}; },
-        []() { return true; },
+        []() { return 0u; },
     },
 };
 
@@ -88,6 +97,8 @@ const SinkDetails& GetOutputSinkDetails(Settings::AudioEngine sink_id) {
     auto iter = find_backend(sink_id);
 
     if (sink_id == Settings::AudioEngine::Auto) {
+        // REVERTED TO 3833 BELOW - DIABLO 3 FIX
+        /*
         // Auto-select a backend. Use the sink details ordering, preferring cubeb first, checking
         // that the backend is available and suitable to use.
         for (auto& details : sink_details) {
@@ -96,14 +107,29 @@ const SinkDetails& GetOutputSinkDetails(Settings::AudioEngine sink_id) {
                 break;
             }
         }
+        */ // END REVERTED CODE - DIABLO 3 FIX
+
+        // BEGIN REINTRODUCED FROM 3833 - REPLACED CODE BLOCK ABOVE - DIABLO 3 FIX
+        // Auto-select a backend. Prefer CubeB, but it may report a large minimum latency which
+        // causes audio issues, in that case go with SDL.
+#if defined(HAVE_CUBEB) && defined(HAVE_SDL2)
+        iter = find_backend(Settings::AudioEngine::Cubeb);
+        if (iter->latency() > TargetSampleCount * 3) {
+            iter = find_backend(Settings::AudioEngine::Sdl2);
+        }
+#else
+        iter = std::begin(sink_details);
+#endif
+        // END REINTRODUCED SECTION FROM 3833 - DIABLO 3 FIX
         LOG_INFO(Service_Audio, "Auto-selecting the {} backend",
                  Settings::CanonicalizeEnum(iter->id));
+    /* BEGIN REMOVED - REVERTING BACK TO 3833, this didn't exist at all. - DIABLO 3 FIX
     } else {
         if (iter != std::end(sink_details) && !iter->is_suitable()) {
             LOG_ERROR(Service_Audio, "Selected backend {} is not suitable, falling back to null",
                       Settings::CanonicalizeEnum(iter->id));
             iter = find_backend(Settings::AudioEngine::Null);
-        }
+        } */ // END REMOVED REVERT - DIABLO 3 FIX
     }
 
     if (iter == std::end(sink_details)) {


### PR DESCRIPTION
Reverts most of this commit (but not all, some parts are still needed, or were reverted already in later EAs): https://github.com/litucks/torzu/commit/39c8ddcda281e5f5b125c78b55741e39a50ff254?style=split&whitespace=show-all&show-outdated= or http://vub63vv26q6v27xzv2dtcd25xumubshogm67yrpaz2rculqxs7jlfqad.onion/torzu-emu/torzu/commit/39c8ddcda281e5f5b125c78b55741e39a50ff254?style=split&whitespace=show-all&show-outdated=

Above commit to the audio sink was first included in EA-3835, changing the way an audio engine is auto-selected by lowest latency... but still doesn't work very well, often using cubeb when it should use SDL.

A side effect of this was that microstuttering was introduced in a few titles. In Diablo 3, the main player character appears to teleport forward a few steps, every couple of steps. It's a consistent, constant stutter when simply walking forward. Occurs for both SDL and cubeb, with cubeb noticeably worse.

3834 and 3833 didn't have this issue with SDL, and the commit above was the bulk of the changes for 3835. Reverting those changes back to the 3833 version has fixed the stutter (for me at least) in D3 as long as SDL is selected (cubeb still stutters). The only observed negative is the audio engine may need to be manually selected in global settings instead of using auto.

Also seems to have fixed intermittent microstutters in TOTK and RDR. Unaware of other titles this may fix, or possibly create a problem for (though creating issues probably is not likely.)